### PR TITLE
Initializer supports grouping regions into a central area as prep for supporting multiple areas

### DIFF
--- a/app/models/covid_tracker/central_area_registration.rb
+++ b/app/models/covid_tracker/central_area_registration.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module CovidTracker
+  class CentralAreaRegistration
+    attr_accessor :country_iso, :province_state, :admin2_county, :regions, :tab_label, :homepage_title
+
+    # @param country_iso [String] country iso for the region at the center of this group of regions
+    # @param province_state [String] province or US state for the region at the center of this group of regions
+    # @param admin2_county [String] admin2 level or US county for the region at the center of this group of regions
+    # @param regions [Array<CovidTracker::Region>] the central area region and regions surrounding the central area
+    # @param tab_label [String] label to display in browser tabs (defaults to central area's region label)
+    # @param homepage_title [String] title to display on the homepage for this central area (defaults to central area's region label)
+    # @returns [CovidTracker::CentralAreaRegistration] new instance of this class
+    def initialize(country_iso: nil, province_state: nil, admin2_county: nil, # rubocop:disable Metrics/ParameterLists
+                   regions: nil, tab_label: nil, homepage_title: nil)
+      validate(regions, country_iso, province_state, admin2_county)
+      @country_iso = country_iso
+      @province_state = province_state
+      @admin2_county = admin2_county
+      @regions = regions
+      @tab_label = tab_label || label
+      @homepage_title = homepage_title || label
+    end
+
+    # @returns [String] the code for the central area's region (e.g. 'usa-alabama-wilcox')
+    def code
+      code = ""
+      code += country_iso.to_s if country_iso.present?
+      code += "-#{province_state}" if province_state.present?
+      code += "-#{admin2_county}" if admin2_county.present?
+      code.tr(' ', '_').downcase
+    end
+
+    # @returns [String] the label for the central area's region (e.g. 'Wilcox, Alabama, USA')
+    def label
+      label = ""
+      label += "#{admin2_county}, " if admin2_county.present?
+      label += "#{province_state}, " if province_state.present?
+      label += country_iso.to_s if country_iso.present?
+      label
+    end
+
+  private
+
+    def validate(regions, country_iso, province_state, admin2_county)
+      raise ArgumentError, "regions is required" if regions.blank?
+      raise ArgumentError, "country_iso is required" if country_iso.blank?
+      raise ArgumentError, "province_state must be defined to include admin2_county" if admin2_county.present? && province_state.blank?
+    end
+  end
+end

--- a/app/models/covid_tracker/region.rb
+++ b/app/models/covid_tracker/region.rb
@@ -6,7 +6,7 @@ module CovidTracker
 
     # @param region_code [String] region code (e.g. "usa-alabama-wilcox")
     # @returns [CovidTracker::Region] instance of this class from covid_tracker_regions database table; creates if not found
-    def self.find_or_create_region_code_for(region_code:)
+    def self.find_or_create_region_for(region_code:)
       region = where(region_code: region_code)
       return region.first unless region.empty?
       new_region = Region.new(region_code: region_code)

--- a/app/models/covid_tracker/region_count.rb
+++ b/app/models/covid_tracker/region_count.rb
@@ -14,7 +14,7 @@ module CovidTracker
       # @returns [CovidTracker::RegionCount] saved instance of this class populated with the data
       def for(region_code:, region_datum:)
         region_count = new
-        region_count.region_id = CovidTracker::Region.find_or_create_region_code_for(region_code: region_code).id
+        region_count.region_id = CovidTracker::Region.find_or_create_region_for(region_code: region_code).id
         region_count.result_code = data_service.result_code(region_datum)
         region_count.result_label = data_service.result_label(region_datum)
         region_count.date = data_service.date(region_datum)
@@ -32,7 +32,7 @@ module CovidTracker
       # @param update [Boolean] if true, update 7 day cumulative count; otherwise, skip update if false
       # @returns [Array<CovidTracker::RegionCount>] instance of this class populated with the retrieved data
       def find_by(region_code:, date: nil, update: true)
-        region_id = CovidTracker::Region.find_or_create_region_code_for(region_code: region_code).id
+        region_id = CovidTracker::Region.find_or_create_region_for(region_code: region_code).id
         where_clause = { region_id: region_id }
         where_clause[:date] = date unless date.blank?
         count_data = where(where_clause)

--- a/app/models/covid_tracker/region_registration.rb
+++ b/app/models/covid_tracker/region_registration.rb
@@ -4,6 +4,10 @@ module CovidTracker
   class RegionRegistration
     attr_accessor :country_iso, :province_state, :admin2_county
 
+    # @param country_iso [String] country iso for the region at the center of this group of regions
+    # @param province_state [String] province or US state for the region at the center of this group of regions
+    # @param admin2_county [String] admin2 level or US county for the region at the center of this group of regions
+    # @returns [CovidTracker::RegionRegistration] new instance of this class
     def initialize(country_iso: nil, province_state: nil, admin2_county: nil)
       validate(country_iso, province_state, admin2_county)
       @country_iso = country_iso
@@ -11,28 +15,29 @@ module CovidTracker
       @admin2_county = admin2_county
     end
 
+    # @returns [String] the code for the region (e.g. 'usa-alabama-wilcox')
     def code
       code = ""
-      code += country_iso.to_s if country_iso
-      code += "-#{province_state}" if province_state
-      code += "-#{admin2_county}" if admin2_county
+      code += country_iso.to_s if country_iso.present?
+      code += "-#{province_state}" if province_state.present?
+      code += "-#{admin2_county}" if admin2_county.present?
       code.tr(' ', '_').downcase
     end
 
+    # @returns [String] the label for the region (e.g. 'Wilcox, Alabama, USA')
     def label
       label = ""
-      label += "#{admin2_county}, " if admin2_county
-      label += "#{province_state}, " if province_state
-      label += country_iso.to_s if country_iso
+      label += "#{admin2_county}, " if admin2_county.present?
+      label += "#{province_state}, " if province_state.present?
+      label += country_iso.to_s if country_iso.present?
       label
     end
 
   private
 
     def validate(country_iso, province_state, admin2_county)
-      raise ArgumentError, "province_state must be defined to include admin2_county" if admin2_county && !province_state
-      # raise ArgumentError, "country_iso must be defined to include province_state" if province_state && !country_iso
-      raise ArgumentError, "country_iso is required" unless country_iso
+      raise ArgumentError, "country_iso is required" if country_iso.blank?
+      raise ArgumentError, "province_state must be defined to include admin2_county" if admin2_county.present? && province_state.blank?
     end
   end
 end

--- a/app/models/covid_tracker/region_registration.rb
+++ b/app/models/covid_tracker/region_registration.rb
@@ -4,15 +4,30 @@ module CovidTracker
   class RegionRegistration
     attr_accessor :country_iso, :province_state, :admin2_county
 
-    # @param country_iso [String] country iso for the region at the center of this group of regions
-    # @param province_state [String] province or US state for the region at the center of this group of regions
-    # @param admin2_county [String] admin2 level or US county for the region at the center of this group of regions
+    # @param country_iso [String] country iso for the region
+    # @param province_state [String] province or US state for the region
+    # @param admin2_county [String] admin2 level or US county for the region
     # @returns [CovidTracker::RegionRegistration] new instance of this class
     def initialize(country_iso: nil, province_state: nil, admin2_county: nil)
       validate(country_iso, province_state, admin2_county)
       @country_iso = country_iso
       @province_state = province_state
       @admin2_county = admin2_county
+    end
+
+    # @param state [String] US state for the region
+    # @param county [String] US county for the region
+    # @returns [CovidTracker::RegionRegistration] new instance of this class
+    def self.for_usa(state: nil, county: nil)
+      self.for(country_iso: 'USA', province_state: state, admin2_county: county)
+    end
+
+    # @param country_iso [String] country iso for the region
+    # @param province_state [String] province or US state for the region
+    # @param admin2_county [String] admin2 level or US county for the region
+    # @returns [CovidTracker::RegionRegistration] new instance of this class
+    def self.for(country_iso: nil, province_state: nil, admin2_county: nil)
+      new(country_iso: country_iso, province_state: province_state, admin2_county: admin2_county)
     end
 
     # @returns [String] the code for the region (e.g. 'usa-alabama-wilcox')

--- a/app/services/covid_tracker/by_region_pages_generator_service.rb
+++ b/app/services/covid_tracker/by_region_pages_generator_service.rb
@@ -2,8 +2,7 @@
 
 module CovidTracker
   class ByRegionPagesGeneratorService
-    class_attribute :registry_class, :time_period_service
-    self.registry_class = CovidTracker::RegionRegistry
+    class_attribute :time_period_service
     self.time_period_service = CovidTracker::TimePeriodService
 
     TAIL_DIRECTORY = "by_region"
@@ -15,11 +14,11 @@ module CovidTracker
     THIS_MONTH = time_period_service::THIS_MONTH
     SINCE_MARCH = time_period_service::SINCE_MARCH
 
-    attr_reader :registered_regions
+    attr_reader :registered_regions # [Array<CovidTracker::RegionRegistration>]
 
-    # @param registered_regions [Array<CovidTracker::RegionRegistration>] registered regions
-    def initialize(registered_regions: registry_class.registry)
-      @registered_regions = registered_regions
+    # @param area [CovidTracker::CentralAreaRegistration] generate sidebar for this area
+    def initialize(area:)
+      @registered_regions = area.regions
     end
 
     # Update all pages for all regions.

--- a/app/services/covid_tracker/central_area_registry.rb
+++ b/app/services/covid_tracker/central_area_registry.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module CovidTracker
+  ##
+  # This registry determines the central location grouping multiple region locations being tracked.
+  #
+  # For organizational purposes and to make the generated code easier to understand, the convention is to use the same
+  # encoding used for regions to identify the region that is the center of the group of regions.  Directories and files
+  # will be assigned names matching the region code for the region representing the central area (e.g. 'usa-alabama-wilcox_sidebar.html')
+  #
+  # @see CovidTracker::RegionRegistration for more information on the structure and creation of region codes
+  #
+  class CentralAreaRegistry
+    include Singleton
+
+    # @param state [String] US state for the region at the center of this group of regions
+    # @param county [String] US county for the region at the center of this group of regions
+    # @param regions [Array<CovidTracker::Region>] the central area region and regions surrounding the central area
+    # @param tab_label [String] label to display in browser tabs (defaults to central area's region label)
+    # @param homepage_title [String] title to display on the homepage for this central area (defaults to central area's region label)
+    def self.register_usa(state: nil, county: nil, regions: nil, tab_label: "", homepage_title: "")
+      regions ||= yield if block_given?
+      raise ArgumentError, "regions is required" if regions.blank?
+      instance.register_usa(state: state, county: county, regions: regions,
+                            tab_label: tab_label, homepage_title: homepage_title)
+    end
+
+    # @param country_iso [String] country iso for the region at the center of this group of regions
+    # @param province_state [String] province or US state for the region at the center of this group of regions
+    # @param admin2_county [String] admin2 level or US county for the region at the center of this group of regions
+    # @param regions [Array<CovidTracker::Region>] the central area region and regions surrounding the central area
+    # @param tab_label [String] label to display in browser tabs (defaults to central area's region label)
+    # @param homepage_title [String] title to display on the homepage for this central area (defaults to central area's region label)
+    def self.register(country_iso:, province_state: nil, admin2_county: nil, # rubocop:disable Metrics/ParameterLists
+                      regions: nil, tab_label: nil, homepage_title: nil)
+      regions ||= yield if block_given?
+      raise ArgumentError, "regions is required" if regions.blank?
+      instance.register(country_iso: country_iso, province_state: province_state,
+                        admin2_county: admin2_county, regions: regions,
+                        tab_label: tab_label, homepage_title: homepage_title)
+    end
+
+    # @returns [Hash<String,CovidTracker::CentralAreaRegistration>] all registered central areas as code=area_registration
+    def self.registry
+      instance.registry
+    end
+
+    # empty the registry
+    def self.clear_registry
+      instance.clear_registry
+    end
+
+    # @param code [String] region code for the registered central region
+    # @returns [CovidTracker::CentralAreaRegistration] the central area registration for the region represented by the code
+    def self.find_by(code:)
+      registry[code]
+    end
+
+    # @returns [Array<CovidTracker::CentralAreaRegistration>] all registered central areas
+    def self.areas
+      registry.values
+    end
+
+    def initialize
+      @central_areas = {}
+    end
+
+    # @param state [String] US state for the region at the center of this group of regions
+    # @param county [String] US county for the region at the center of this group of regions
+    # @param regions [Array<CovidTracker::Region>] the central area region and regions surrounding the central area
+    # @param tab_label [String] label to display in browser tabs (defaults to central area's region label)
+    # @param homepage_title [String] title to display on the homepage for this central area (defaults to central area's region label)
+    def register_usa(state: nil, county: nil, regions:, tab_label: nil, homepage_title: nil)
+      register(country_iso: 'USA', province_state: state, admin2_county: county, regions: regions,
+               tab_label: tab_label, homepage_title: homepage_title)
+    end
+
+    # @param country_iso [String] country iso for the region at the center of this group of regions
+    # @param province_state [String] province or US state for the region at the center of this group of regions
+    # @param admin2_county [String] admin2 level or US county for the region at the center of this group of regions
+    # @param regions [Array<CovidTracker::Region>] the central area region and regions surrounding the central area
+    # @param tab_label [String] label to display in browser tabs (defaults to central area's region label)
+    # @param homepage_title [String] title to display on the homepage for this central area (defaults to central area's region label)
+    def register(country_iso:, province_state: nil, admin2_county: nil, # rubocop:disable Metrics/ParameterLists
+                 regions:, tab_label: nil, homepage_title: nil)
+      central_area = CovidTracker::CentralAreaRegistration.new(country_iso: country_iso,
+                                                               province_state: province_state,
+                                                               admin2_county: admin2_county,
+                                                               regions: regions,
+                                                               tab_label: tab_label,
+                                                               homepage_title: homepage_title)
+      @central_areas[central_area.code] = central_area
+      central_area.code
+    end
+
+    # @returns [Hash<String,CovidTracker::CentralAreaRegistration>] all registered central areas as code=area_registration
+    def registry
+      @central_areas
+    end
+
+    # empty the registry
+    def clear_registry
+      @central_areas = {}
+    end
+  end
+end

--- a/app/services/covid_tracker/daily_graphs_generator_service.rb
+++ b/app/services/covid_tracker/daily_graphs_generator_service.rb
@@ -5,8 +5,7 @@ require 'covid_tracker/keys'
 # This class generates graphs for each stat tracked.
 module CovidTracker
   class DailyGraphsGeneratorService
-    class_attribute :registry_class, :data_service, :data_retrieval_service, :graph_service, :time_period_service
-    self.registry_class = CovidTracker::RegionRegistry
+    class_attribute :data_service, :data_retrieval_service, :graph_service, :time_period_service
     self.data_service = CovidTracker::DataService
     self.data_retrieval_service = CovidTracker::DataRetrievalService
     self.graph_service = CovidTracker::GruffGraphService
@@ -20,11 +19,11 @@ module CovidTracker
     THIS_MONTH = time_period_service::THIS_MONTH
     SINCE_MARCH = time_period_service::SINCE_MARCH
 
-    attr_reader :registered_regions
+    attr_reader :registered_regions # [Array<CovidTracker::RegionRegistration>]
 
-    # @param registered_regions [Array<CovidTracker::RegionRegistration>] registered regions
-    def initialize(registered_regions: registry_class.registry)
-      @registered_regions = registered_regions
+    # @param area [CovidTracker::CentralAreaRegistration] generate sidebar for this area
+    def initialize(area:)
+      @registered_regions = area.regions
     end
 
     # Update all graphs for all time periods.

--- a/app/services/covid_tracker/daily_pages_generator_service.rb
+++ b/app/services/covid_tracker/daily_pages_generator_service.rb
@@ -2,8 +2,7 @@
 
 module CovidTracker
   class DailyPagesGeneratorService
-    class_attribute :registry_class, :time_period_service
-    self.registry_class = CovidTracker::RegionRegistry
+    class_attribute :time_period_service
     self.time_period_service = CovidTracker::TimePeriodService
 
     PAGE_DIRECTORY = File.join("docs", "pages", "covid_tracker")
@@ -15,11 +14,11 @@ module CovidTracker
     ALL_REGIONS_LABEL = CovidTracker::SiteGeneratorService::ALL_REGIONS_LABEL
     ALL_REGIONS_CODE = CovidTracker::SiteGeneratorService::ALL_REGIONS_CODE
 
-    attr_reader :registered_regions
+    attr_reader :registered_regions # [Array<CovidTracker::RegionRegistration>]
 
-    # @param registered_regions [Array<CovidTracker::RegionRegistration>] registered regions
-    def initialize(registered_regions: registry_class.registry)
-      @registered_regions = registered_regions
+    # @param area [CovidTracker::CentralAreaRegistration] generate sidebar for this area
+    def initialize(area:)
+      @registered_regions = area.regions
     end
 
     # Update all pages for all time periods.

--- a/app/services/covid_tracker/sidebar_generator_service.rb
+++ b/app/services/covid_tracker/sidebar_generator_service.rb
@@ -15,11 +15,11 @@ module CovidTracker
     ALL_REGIONS_LABEL = CovidTracker::SiteGeneratorService::ALL_REGIONS_LABEL
     ALL_REGIONS_CODE = CovidTracker::SiteGeneratorService::ALL_REGIONS_CODE
 
-    attr_reader :registered_regions
+    attr_reader :registered_regions # [Array<CovidTracker::RegionRegistration>]
 
-    # @param registered_regions [Array<CovidTracker::RegionRegistration>] registered regions
-    def initialize(registered_regions: registry_class.registry)
-      @registered_regions = registered_regions
+    # @param area [CovidTracker::CentralAreaRegistration] generate sidebar for this area
+    def initialize(area:)
+      @registered_regions = area.regions
     end
 
     # Update sidebar for all time periods.

--- a/app/services/covid_tracker/site_generator_service.rb
+++ b/app/services/covid_tracker/site_generator_service.rb
@@ -2,53 +2,59 @@
 
 module CovidTracker
   class SiteGeneratorService
-    class_attribute :registry_class
-    self.registry_class = CovidTracker::RegionRegistry
+    class_attribute :registry_class, :central_area_registry
+    self.registry_class = CovidTracker::CentralAreaRegistry
+    self.central_area_registry = CovidTracker::CentralAreaRegistry
 
     ALL_REGIONS_LABEL = "All Regions"
     ALL_REGIONS_CODE = "all_regions"
 
-    # @param days [Integer] number of days of data to fetch
-    # @return [Hash] full set of data for all configured regions - see example in class documentation
     class << self
       def update_site
-        registered_regions = registry_class.registry
-        update_sidebar(registered_regions: registered_regions)
-        update_daily_pages(registered_regions: registered_regions)
-        update_weekly_pages(registered_regions: registered_regions)
-        update_by_region_pages(registered_regions: registered_regions)
-        update_daily_graphs(registered_regions: registered_regions)
-        update_weekly_graphs(registered_regions: registered_regions)
+        update_sidebar
+        update_daily_pages
+        update_weekly_pages
+        update_by_region_pages
+        update_daily_graphs
+        update_weekly_graphs
       end
 
-      def update_sidebar(registered_regions: registry_class.registry)
-        generator = CovidTracker::SidebarGeneratorService.new(registered_regions: registered_regions)
-        generator.update_sidebar
+      # @param central_area_code [String] code for the area to generate; all areas if nil
+      def update_sidebar(central_area_code: nil)
+        areas = areas(central_area_code)
+        areas.each { |area| CovidTracker::SidebarGeneratorService.new(area: area).update_sidebar }
       end
 
-      def update_daily_pages(registered_regions: registry_class.registry)
-        generator = CovidTracker::DailyPagesGeneratorService.new(registered_regions: registered_regions)
-        generator.update_pages
+      def update_daily_pages(central_area_code: nil)
+        areas = areas(central_area_code)
+        areas.each { |area| CovidTracker::DailyPagesGeneratorService.new(area: area).update_pages }
       end
 
-      def update_weekly_pages(registered_regions: registry_class.registry)
-        generator = CovidTracker::WeeklyPagesGeneratorService.new(registered_regions: registered_regions)
-        generator.update_pages
+      def update_weekly_pages(central_area_code: nil)
+        areas = areas(central_area_code)
+        areas.each { |area| CovidTracker::WeeklyPagesGeneratorService.new(area: area).update_pages }
       end
 
-      def update_by_region_pages(registered_regions: registry_class.registry)
-        generator = CovidTracker::ByRegionPagesGeneratorService.new(registered_regions: registered_regions)
-        generator.update_pages
+      def update_by_region_pages(central_area_code: nil)
+        areas = areas(central_area_code)
+        areas.each { |area| CovidTracker::ByRegionPagesGeneratorService.new(area: area).update_pages }
       end
 
-      def update_daily_graphs(registered_regions: registry_class.registry)
-        generator = CovidTracker::DailyGraphsGeneratorService.new(registered_regions: registered_regions)
-        generator.update_graphs
+      def update_daily_graphs(central_area_code: nil)
+        areas = areas(central_area_code)
+        areas.each { |area| CovidTracker::DailyGraphsGeneratorService.new(area: area).update_graphs }
       end
 
-      def update_weekly_graphs(registered_regions: registry_class.registry)
-        generator = CovidTracker::WeeklyGraphsGeneratorService.new(registered_regions: registered_regions)
-        generator.update_graphs
+      def update_weekly_graphs(central_area_code: nil)
+        areas = areas(central_area_code)
+        areas.each { |area| CovidTracker::WeeklyGraphsGeneratorService.new(area: area).update_graphs }
+      end
+
+    private
+
+      def areas(central_area_code)
+        return central_area_registry.areas if central_area_code.blank?
+        [central_area_registry.find_by(code: central_area_code)]
       end
     end
   end

--- a/app/services/covid_tracker/weekly_graphs_generator_service.rb
+++ b/app/services/covid_tracker/weekly_graphs_generator_service.rb
@@ -5,8 +5,7 @@ require 'covid_tracker/keys'
 # This class generates graphs for each stat tracked.
 module CovidTracker
   class WeeklyGraphsGeneratorService
-    class_attribute :registry_class, :data_service, :data_retrieval_service, :graph_service, :time_period_service
-    self.registry_class = CovidTracker::RegionRegistry
+    class_attribute :data_service, :data_retrieval_service, :graph_service, :time_period_service
     self.data_service = CovidTracker::DataService
     self.data_retrieval_service = CovidTracker::DataRetrievalService
     self.graph_service = CovidTracker::GruffGraphService
@@ -19,11 +18,11 @@ module CovidTracker
 
     SINCE_MARCH = time_period_service::SINCE_MARCH
 
-    attr_reader :registered_regions
+    attr_reader :registered_regions # [Array<CovidTracker::RegionRegistration>]
 
-    # @param registered_regions [Array<CovidTracker::RegionRegistration>] registered regions
-    def initialize(registered_regions: registry_class.registry)
-      @registered_regions = registered_regions
+    # @param area [CovidTracker::CentralAreaRegistration] generate sidebar for this area
+    def initialize(area:)
+      @registered_regions = area.regions
     end
 
     # Generate weekly graphs for all regions

--- a/app/services/covid_tracker/weekly_pages_generator_service.rb
+++ b/app/services/covid_tracker/weekly_pages_generator_service.rb
@@ -2,8 +2,7 @@
 
 module CovidTracker
   class WeeklyPagesGeneratorService
-    class_attribute :registry_class, :time_period_service
-    self.registry_class = CovidTracker::RegionRegistry
+    class_attribute :time_period_service
     self.time_period_service = CovidTracker::TimePeriodService
 
     TAIL_DIRECTORY = "weekly_totals"
@@ -18,11 +17,11 @@ module CovidTracker
     ALL_REGIONS_LABEL = CovidTracker::SiteGeneratorService::ALL_REGIONS_LABEL
     ALL_REGIONS_CODE = CovidTracker::SiteGeneratorService::ALL_REGIONS_CODE
 
-    attr_reader :registered_regions
+    attr_reader :registered_regions # [Array<CovidTracker::RegionRegistration>]
 
-    # @param registered_regions [Array<CovidTracker::RegionRegistration>] registered regions
-    def initialize(registered_regions: registry_class.registry)
-      @registered_regions = registered_regions
+    # @param area [CovidTracker::CentralAreaRegistration] generate sidebar for this area
+    def initialize(area:)
+      @registered_regions = area.regions
     end
 
     # Update all pages for all time periods.

--- a/config/initializers/covid_regions.rb
+++ b/config/initializers/covid_regions.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
-# Registering regions to track
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Cortland')
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Tompkins')
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Broome')
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Onondaga')
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Cayuga')
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Madison')
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Chenango')
-CovidTracker::RegionRegistry.register_usa(state: 'New York', county: 'Tioga')
+# Registering regions in a central area
+CovidTracker::CentralAreaRegistry.register_usa(state: 'New York', county: 'Cortland',
+                                               tab_label: "Cortland County, NY",
+                                               homepage_title: "Cortland County, NY and Surrounding Counties") do
+  [
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Cortland'),
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Tompkins'),
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Broome'),
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Onondaga'),
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Cayuga'),
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Madison'),
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Chenango'),
+    CovidTracker::RegionRegistration.for_usa(state: 'New York', county: 'Tioga')
+  ]
+end

--- a/spec/models/central_area_registration_spec.rb
+++ b/spec/models/central_area_registration_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CovidTracker::CentralAreaRegistration do
+  include_context "shared central area registration 1"
+
+  describe 'attr_readers' do
+    let(:subject) do
+      described_class.new(country_iso: country_iso_label_central_area_1,
+                          province_state: province_state_label_central_area_1,
+                          admin2_county: admin2_county_label_central_area_1,
+                          regions: central_area_1_regions,
+                          tab_label: central_area_1_tab_label,
+                          homepage_title: central_area_1_homepage_title)
+    end
+
+    it { is_expected.to respond_to(:code) }
+    it { is_expected.to respond_to(:label) }
+    it { is_expected.to respond_to(:country_iso) }
+    it { is_expected.to respond_to(:province_state) }
+    it { is_expected.to respond_to(:admin2_county) }
+    it { is_expected.to respond_to(:regions) }
+    it { is_expected.to respond_to(:tab_label) }
+    it { is_expected.to respond_to(:homepage_title) }
+  end
+
+  describe '.new' do
+    context 'when regions is not specified' do
+      it 'raises Argument error' do
+        expect { described_class.new }.to raise_error ArgumentError, 'regions is required'
+      end
+    end
+
+    context 'when regions is specified' do
+      context 'and country is not specified' do
+        it 'raises Argument error' do
+          expect { described_class.new(regions: central_area_1_regions) }
+            .to raise_error ArgumentError, 'country_iso is required'
+        end
+      end
+
+      context 'and country is specified' do
+        context 'and state is not specified' do
+          context 'and county is specified' do
+            it 'raises Argument error' do
+              expect { described_class.new(regions: central_area_1_regions, country_iso: 'USA', admin2_county: 'Richmond') }
+                .to raise_error ArgumentError, 'province_state must be defined to include admin2_county'
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#code' do
+    context 'when county is not specified' do
+      context 'and state is not specified' do
+        let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA') }
+        it 'only includes USA' do
+          expect(registration.code).to eq 'usa'
+        end
+      end
+
+      context 'and state is specified' do
+        let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'Virginia') }
+        it 'includes USA and state' do
+          expect(registration.code).to eq 'usa-virginia'
+        end
+      end
+    end
+
+    context 'when state and county are specified' do
+      let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'New York', admin2_county: 'Broome') }
+      it 'includes USA, state, and county' do
+        expect(registration.code).to eq 'usa-new_york-broome'
+      end
+    end
+  end
+
+  describe '#label' do
+    context 'when county is not specified' do
+      context 'and state is not specified' do
+        let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA') }
+        it 'only includes USA' do
+          expect(registration.label).to eq 'USA'
+        end
+      end
+
+      context 'and state is specified' do
+        let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'Virginia') }
+        it 'includes USA and state' do
+          expect(registration.label).to eq 'Virginia, USA'
+        end
+      end
+    end
+
+    context 'when state and county are specified' do
+      let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'New York', admin2_county: 'Broome') }
+      it 'includes USA, state, and county' do
+        expect(registration.label).to eq 'Broome, New York, USA'
+      end
+    end
+  end
+
+  describe '#tab_label' do
+    context 'when not specified' do
+      let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'New York', admin2_county: 'Broome') }
+      it "defaults to central area's label" do
+        expect(registration.tab_label).to eq 'Broome, New York, USA'
+      end
+    end
+
+    context 'when specified' do
+      let(:custom_tab_label) { 'Custom Tab Label' }
+      let(:registration) do
+        described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'New York',
+                            admin2_county: 'Broome', tab_label: custom_tab_label)
+      end
+      it "returns passed in tab label" do
+        expect(registration.tab_label).to eq custom_tab_label
+      end
+    end
+  end
+
+  describe '#homepage_title' do
+    context 'when not specified' do
+      let(:registration) { described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'New York', admin2_county: 'Broome') }
+      it "defaults to central area's label" do
+        expect(registration.homepage_title).to eq 'Broome, New York, USA'
+      end
+    end
+
+    context 'when specified' do
+      let(:custom_homepage_title) { 'Custom Homepage Title' }
+      let(:registration) do
+        described_class.new(regions: central_area_1_regions, country_iso: 'USA', province_state: 'New York',
+                            admin2_county: 'Broome', homepage_title: custom_homepage_title)
+      end
+      it "returns passed in homepage title" do
+        expect(registration.homepage_title).to eq custom_homepage_title
+      end
+    end
+  end
+end

--- a/spec/models/region_registration_spec.rb
+++ b/spec/models/region_registration_spec.rb
@@ -13,18 +13,126 @@ RSpec.describe CovidTracker::RegionRegistration do
   end
 
   describe '.new' do
-    context 'when country is not specified' do
+    context 'when country_iso is not specified' do
       it 'raises Argument error' do
         expect { described_class.new }.to raise_error ArgumentError, 'country_iso is required'
       end
     end
 
-    context 'when country is specified' do
-      context 'and state is not specified' do
-        context 'and county is specified' do
+    context 'when country_iso is specified' do
+      context 'and province_state is not specified' do
+        context 'and admin2_county is not specified' do
+          let(:registration) { described_class.new(country_iso: 'DEU') }
+          it 'creates the registration' do
+            expect(registration).to be_kind_of described_class
+            expect(registration.code).to eq 'deu'
+          end
+        end
+
+        context 'and admin2_county is specified' do
           it 'raises Argument error' do
             expect { described_class.new(country_iso: 'USA', admin2_county: 'Richmond') }
               .to raise_error ArgumentError, 'province_state must be defined to include admin2_county'
+          end
+        end
+      end
+
+      context 'and province_state is specified' do
+        context 'and admin2_county is not specified' do
+          let(:registration) { described_class.new(country_iso: 'USA', province_state: 'Georgia') }
+          it 'creates the registration' do
+            expect(registration).to be_kind_of described_class
+            expect(registration.code).to eq 'usa-georgia'
+          end
+        end
+
+        context 'and admin2_county is specified' do
+          let(:registration) { described_class.new(country_iso: 'USA', province_state: 'Georgia', admin2_county: 'Richmond') }
+          it 'creates the registration' do
+            expect(registration).to be_kind_of described_class
+            expect(registration.code).to eq 'usa-georgia-richmond'
+          end
+        end
+      end
+    end
+  end
+
+  describe '.for_usa' do
+    context 'when state is not specified' do
+      context 'and county is not specified' do
+        let(:registration) { described_class.for_usa }
+        it 'creates the registration' do
+          expect(registration).to be_kind_of described_class
+          expect(registration.code).to eq 'usa'
+        end
+      end
+
+      context 'and county is specified' do
+        it 'raises Argument error' do
+          expect { described_class.for_usa(county: 'Richmond') }
+            .to raise_error ArgumentError, 'province_state must be defined to include admin2_county'
+        end
+      end
+    end
+
+    context 'and state is specified' do
+      context 'and county is not specified' do
+        let(:registration) { described_class.for_usa(state: 'Georgia') }
+        it 'creates the registration' do
+          expect(registration).to be_kind_of described_class
+          expect(registration.code).to eq 'usa-georgia'
+        end
+      end
+
+      context 'and county is specified' do
+        let(:registration) { described_class.for_usa(state: 'Georgia', county: 'Richmond') }
+        it 'creates the registration' do
+          expect(registration).to be_kind_of described_class
+          expect(registration.code).to eq 'usa-georgia-richmond'
+        end
+      end
+    end
+  end
+
+  describe '.for' do
+    context 'when country_iso is not specified' do
+      it 'raises Argument error' do
+        expect { described_class.for }.to raise_error ArgumentError, 'country_iso is required'
+      end
+    end
+
+    context 'when country_iso is specified' do
+      context 'and province_state is not specified' do
+        context 'and admin2_county is not specified' do
+          let(:registration) { described_class.for(country_iso: 'DEU') }
+          it 'creates the registration' do
+            expect(registration).to be_kind_of described_class
+            expect(registration.code).to eq 'deu'
+          end
+        end
+
+        context 'and admin2_county is specified' do
+          it 'raises Argument error' do
+            expect { described_class.for(country_iso: 'USA', admin2_county: 'Richmond') }
+              .to raise_error ArgumentError, 'province_state must be defined to include admin2_county'
+          end
+        end
+      end
+
+      context 'and province_state is specified' do
+        context 'and admin2_county is not specified' do
+          let(:registration) { described_class.for(country_iso: 'USA', province_state: 'Georgia') }
+          it 'creates the registration' do
+            expect(registration).to be_kind_of described_class
+            expect(registration.code).to eq 'usa-georgia'
+          end
+        end
+
+        context 'and admin2_county is specified' do
+          let(:registration) { described_class.for(country_iso: 'USA', province_state: 'Georgia', admin2_county: 'Richmond') }
+          it 'creates the registration' do
+            expect(registration).to be_kind_of described_class
+            expect(registration.code).to eq 'usa-georgia-richmond'
           end
         end
       end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe CovidTracker::Region do
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:region_code) }
 
-  describe 'find_or_create_region_code_for' do
+  describe 'find_or_create_region_for' do
     let!(:region) { FactoryBot.create(:region, id: existing_region_id, region_code: existing_region_code) }
     let(:existing_region_code) { 'usa-new_york-cortland' }
     let(:existing_region_id) { 1 }
     context 'when code exists' do
       it 'returns the an instance of the described_class' do
-        result = described_class.find_or_create_region_code_for(region_code: existing_region_code)
+        result = described_class.find_or_create_region_for(region_code: existing_region_code)
         expect(result).to be_kind_of described_class
         expect(result.id).to eq existing_region_id
         expect(result.region_code).to eq existing_region_code
@@ -23,7 +23,7 @@ RSpec.describe CovidTracker::Region do
       let(:non_existent_region_code) { 'usa-colorado-broomfield' }
       let(:new_region_id) { 2 }
       it 'creates a record for the code and returns the id' do
-        result = described_class.find_or_create_region_code_for(region_code: non_existent_region_code)
+        result = described_class.find_or_create_region_for(region_code: non_existent_region_code)
         expect(result).to be_kind_of described_class
         expect(result.id).to eq new_region_id
         expect(result.region_code).to eq non_existent_region_code

--- a/spec/services/central_area_registry_spec.rb
+++ b/spec/services/central_area_registry_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CovidTracker::CentralAreaRegistry do
     context 'when regions is specified' do
       context 'and country iso is not specified' do
         it 'raises argument error exception' do
-          expect { described_class.register(regions: central_area_1_regions) }.to raise_error ArgumentError, 'missing keyword: country_iso'
+          expect { described_class.register(regions: central_area_1_regions) }.to raise_error ArgumentError
         end
       end
 

--- a/spec/services/central_area_registry_spec.rb
+++ b/spec/services/central_area_registry_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CovidTracker::CentralAreaRegistry do
+  include_context "shared central area registration 1"
+
+  before { described_class.clear_registry }
+
+  subject { described_class.registry }
+  describe '.register_usa' do
+    context 'when regions is not specified' do
+      it 'raises Argument error' do
+        expect { described_class.register_usa }.to raise_error ArgumentError, 'regions is required'
+      end
+    end
+
+    context 'when county is not specified' do
+      let(:central_area_codes) { subject.keys }
+      let(:central_area_code) { central_area_codes.first }
+      let(:registration) { subject[central_area_code] }
+
+      context 'and state is not specified' do
+        before { described_class.register_usa(regions: central_area_1_regions) }
+        it 'only includes USA' do
+          expect(central_area_code).to eq 'usa'
+          expect(registration).to be_kind_of CovidTracker::CentralAreaRegistration
+          expect(registration.country_iso).to eq 'USA'
+          expect(registration.province_state).to be_nil
+          expect(registration.admin2_county).to be_nil
+        end
+      end
+
+      context 'and state is specified' do
+        before { described_class.register_usa(regions: central_area_1_regions, state: 'Virginia') }
+        it 'includes USA and state' do
+          expect(central_area_code).to eq 'usa-virginia'
+          expect(registration).to be_kind_of CovidTracker::CentralAreaRegistration
+          expect(registration.country_iso).to eq 'USA'
+          expect(registration.province_state).to eq 'Virginia'
+          expect(registration.admin2_county).to be_nil
+        end
+      end
+    end
+
+    context 'when county is specified' do
+      context 'and state is not specified' do
+        it 'raises ArgumentError' do
+          expect { described_class.register_usa(regions: central_area_1_regions, county: 'Broome') }
+            .to raise_error ArgumentError, 'province_state must be defined to include admin2_county'
+        end
+      end
+
+      context 'and state is specified' do
+        before { described_class.register_usa(regions: central_area_1_regions, state: 'New York', county: 'Broome') }
+        let(:central_area_codes) { subject.keys }
+        let(:central_area_code) { central_area_codes.first }
+        let(:registration) { subject[central_area_code] }
+        it 'includes USA, state, and county' do
+          expect(central_area_code).to eq 'usa-new_york-broome'
+          expect(registration).to be_kind_of CovidTracker::CentralAreaRegistration
+          expect(registration.country_iso).to eq 'USA'
+          expect(registration.province_state).to eq 'New York'
+          expect(registration.admin2_county).to eq 'Broome'
+        end
+      end
+    end
+  end
+
+  describe '.register' do
+    context 'when regions is not specified' do
+      it 'raises Argument error' do
+        expect { described_class.register(country_iso: 'usa') }.to raise_error ArgumentError, 'regions is required'
+      end
+    end
+
+    context 'when regions is specified' do
+      context 'and country iso is not specified' do
+        it 'raises argument error exception' do
+          expect { described_class.register(regions: central_area_1_regions) }.to raise_error ArgumentError, 'missing keyword: country_iso'
+        end
+      end
+
+      context 'and country iso is specified' do
+        let(:central_area_codes) { subject.keys }
+        let(:central_area_code) { central_area_codes.first }
+        let(:registration) { subject[central_area_code] }
+        context 'and admin2 is not specified' do
+          context 'and province is not specified' do
+            before { described_class.register(regions: central_area_1_regions, country_iso: 'CHN') }
+            it 'only includes country iso' do
+              expect(central_area_code).to eq 'chn'
+              expect(registration).to be_kind_of CovidTracker::CentralAreaRegistration
+              expect(registration.country_iso).to eq 'CHN'
+              expect(registration.province_state).to be_nil
+              expect(registration.admin2_county).to be_nil
+            end
+          end
+
+          context 'and province is specified' do
+            before { described_class.register(regions: central_area_1_regions, country_iso: 'DEU', province_state: 'Berlin') }
+            let(:central_area_codes) { subject.keys }
+            let(:central_area_code) { central_area_codes.first }
+            let(:registration) { subject[central_area_code] }
+            it 'includes USA and state' do
+              expect(central_area_code).to eq 'deu-berlin'
+              expect(registration).to be_kind_of CovidTracker::CentralAreaRegistration
+              expect(registration.country_iso).to eq 'DEU'
+              expect(registration.province_state).to eq 'Berlin'
+              expect(registration.admin2_county).to be_nil
+            end
+          end
+        end
+
+        context 'and admin2 and province are specified' do
+          before { described_class.register(regions: central_area_1_regions, country_iso: 'USA', province_state: 'Georgia', admin2_county: 'Columbia') }
+          let(:central_area_codes) { subject.keys }
+          let(:central_area_code) { central_area_codes.first }
+          let(:registration) { subject[central_area_code] }
+          it 'includes USA, state, and county' do
+            expect(central_area_code).to eq 'usa-georgia-columbia'
+            expect(registration).to be_kind_of CovidTracker::CentralAreaRegistration
+            expect(registration.country_iso).to eq 'USA'
+            expect(registration.province_state).to eq 'Georgia'
+            expect(registration.admin2_county).to eq 'Columbia'
+          end
+        end
+      end
+    end
+
+    # NOTE: This looks like it is checking registering the same area with multiple regions, but it is actually calling
+    #       central_area_registry multiple times with the same regions, which is ok, but uncommon.  It does test the
+    #       desired functionality of registering multiple areas.
+    context 'when called multiple times' do
+      before do
+        described_class.register(regions: central_area_1_regions, country_iso: 'ALB')
+        described_class.register(regions: central_area_1_regions, country_iso: 'AUS', province_state: 'Victoria')
+        described_class.register(regions: central_area_1_regions, country_iso: 'USA', province_state: 'Colorado', admin2_county: 'Broomfield')
+      end
+
+      it 'has a registration for each country registered' do
+        countries = subject.values.map(&:country_iso)
+        expect(countries).to contain_exactly('USA', 'AUS', 'ALB')
+      end
+
+      it 'registers multiple regions' do # rubocop:disable RSpec/ExampleLength
+        subject.each_value do |registration|
+          case registration.country_iso
+          when 'USA'
+            expect(registration.country_iso).to eq 'USA'
+            expect(registration.province_state).to eq 'Colorado'
+            expect(registration.admin2_county).to eq 'Broomfield'
+          when 'AUS'
+            expect(registration.country_iso).to eq 'AUS'
+            expect(registration.province_state).to eq 'Victoria'
+            expect(registration.admin2_county).to be_nil
+          when 'ALB'
+            expect(registration.country_iso).to eq 'ALB'
+            expect(registration.province_state).to be_nil
+            expect(registration.admin2_county).to be_nil
+          end
+        end
+      end
+    end
+  end
+
+  describe '.find_by' do
+    before do
+      described_class.register(regions: central_area_1_regions, country_iso: 'ALB')
+      described_class.register(regions: central_area_1_regions, country_iso: 'AUS', province_state: 'Victoria')
+      described_class.register(regions: central_area_1_regions, country_iso: 'USA', province_state: 'Colorado', admin2_county: 'Broomfield')
+    end
+    let(:registration) { described_class.find_by(code: 'aus-victoria') }
+    it 'finds registration given the central area code' do
+      expect(registration.country_iso).to eq 'AUS'
+      expect(registration.province_state).to eq 'Victoria'
+      expect(registration.admin2_county).to be_nil
+    end
+  end
+
+  describe '.areas' do
+    before do
+      described_class.register(regions: central_area_1_regions, country_iso: 'ALB')
+      described_class.register(regions: central_area_1_regions, country_iso: 'AUS', province_state: 'Victoria')
+      described_class.register(regions: central_area_1_regions, country_iso: 'USA', province_state: 'Colorado', admin2_county: 'Broomfield')
+    end
+    let(:registrations) { described_class.areas }
+    it 'finds registration given the central area code' do
+      expect(registrations).to be_kind_of Array
+      expect(registrations.count).to eq 3
+      expect(registrations.first).to be_kind_of CovidTracker::CentralAreaRegistration
+      expect(registrations.map(&:country_iso)).to match_array ['ALB', 'AUS', 'USA']
+    end
+  end
+end

--- a/spec/support/shared_central_area_registration_1.rb
+++ b/spec/support/shared_central_area_registration_1.rb
@@ -1,0 +1,27 @@
+RSpec.shared_context "shared central area registration 1", shared_context: :metadata do
+  include_context "shared region registration 1"
+  include_context "shared region registration 2"
+
+  let(:country_iso_label_central_area_1) { country_iso_label_region_1 }
+  let(:province_state_label_central_area_1) { province_state_label_region_1 }
+  let(:admin2_county_label_central_area_1) { admin2_county_label_region_1 }
+
+  let(:central_area_1_region_1) { region_registration_1 }
+  let(:central_area_1_region_2) { region_registration_2 }
+  let(:central_area_1_regions) { [central_area_1_region_1, central_area_1_region_2] }
+
+  let(:central_area_1_tab_label) { "tab: #{region_registration_1.label}" }
+  let(:central_area_1_homepage_title) { "hpt: #{region_registration_1.label}" }
+
+  let(:central_area_1_code) { region_1_code }
+  let(:central_area_1_label) { region_1_label }
+
+  let(:central_area_registration_1) do
+    CovidTracker::CentralAreaRegistration.new(country_iso: country_iso_label_central_area_1,
+                                              province_state: province_state_label_central_area_1,
+                                              admin2_county: admin2_county_label_central_area_1,
+                                              regions: central_area_1_regions,
+                                              tab_label: central_area_1_tab_label,
+                                              homepage_title: central_area_1_homepage_title)
+  end
+end


### PR DESCRIPTION
Remaining Work:

At this point, all generators work when there is only one central area.

## To be able to use with multiple central areas:

### Central Areas page
- Need to generate index.html and add each central area to the list

### homepage
- Need to generate a homepage for each cental area.
- Homepage frontmatter needs to specify sidebar generated for this area.
- Need to use title from central area registration for homepage title.
- Links to graphs need to go to pages generated for this area.

### sidebar
- Need to update to have multiple sidebars, one for each central area.
- Need to generate _includes/custom/sidebarconfigs.html to include a definition for each sidebar.
- Each sidebar should be named for the central area code.
- The link at the top of the sidebar should go to homepage for the central area.
- All page links need to include the cental area code as the directory name for the permanent link to each page

### pages
- Need to update to put pages in subdirectory named for the central area code.
- Need to update front matter to put permanent link in a subdirectory named for the cental area code.

### graphs
- Graphs can continue to generate to a single directory.  No additional changes required.

### README
- update README to include instructions for registering central areas with regions